### PR TITLE
feat: support auth with personal access token from github

### DIFF
--- a/.env
+++ b/.env
@@ -11,6 +11,7 @@ VAULT_MANAGER_KEY=manager
 # Change if you are using a different network or want to connect to a remote vault
 VAULT_BASE_URL=http://vault:8200
 VAULT_LOCAL_URL=http://localhost:8200
+VAULT_NAMESPACE=
 
 # DEFAULT ROLE ID and SECRET ID for the user to access the vault
 # REPLACE WITH YOUR OWN VALUES

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/platform-express": "^10.4.15",
     "@nestjs/swagger": "^8.1.0",
-    "axios": "^1.7.9",
+    "axios": "^1.8.2",
     "bip39": "^3.1.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -3,19 +3,16 @@ import { JwtService } from '@nestjs/jwt';
 import { AuthService } from './auth.service';
 import { SignInResponseDto } from './sign-in.dto';
 import { UnauthorizedException } from '@nestjs/common';
+import createMockInstance from 'jest-create-mock-instance';
 
 describe('AuthService', () => {
   let authService: AuthService;
-  let vaultServiceMock: VaultService;
-  let jwtServiceMock: JwtService;
+  let vaultServiceMock: jest.Mocked<VaultService>;
+  let jwtServiceMock: jest.Mocked<JwtService>;
 
   beforeEach(() => {
-    vaultServiceMock = {
-      checkToken: jest.fn(),
-    } as any;
-    jwtServiceMock = {
-      signAsync: jest.fn(),
-    } as any;
+    vaultServiceMock = createMockInstance(VaultService);
+    jwtServiceMock = createMockInstance(JwtService);
 
     authService = new AuthService(vaultServiceMock, jwtServiceMock);
   });
@@ -42,4 +39,13 @@ describe('AuthService', () => {
     expect(vaultServiceMock.checkToken).toHaveBeenCalledWith(vaultToken);
     expect(jwtServiceMock.signAsync).not.toHaveBeenCalled();
   });
+
+  it('\(OK) authGithub should return vault token on successful authentication', async () => {
+    const githubPAT: string = 'test_github_pat';
+
+    (vaultServiceMock.authGithub as jest.Mock).mockResolvedValue('test_vault_token');
+    const result = await authService.authGithub(githubPAT);
+    expect(result).toEqual('test_vault_token');
+    expect(vaultServiceMock.authGithub).toHaveBeenCalledWith(githubPAT);
+  })
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -34,4 +34,10 @@ export class AuthService {
 
     return response as SignInResponseDto;
   }
+
+  async authGithub(token: string): Promise<string> {
+    const vault_token = await this.vaultService.authGithub(token);
+    return vault_token
+  }
+
 }

--- a/src/vault/vault.service.ts
+++ b/src/vault/vault.service.ts
@@ -114,6 +114,7 @@ export class VaultService {
 
   public async sign(keyName: string, transitPath: string, data: Uint8Array, token: string): Promise<Buffer> {
     const baseUrl: string = this.configService.get<string>('VAULT_BASE_URL');
+    const vaultNamespace: string = this.configService.get<string>('VAULT_NAMESPACE');
 
     let result: AxiosResponse;
     try {
@@ -125,6 +126,7 @@ export class VaultService {
         {
           headers: {
             'X-Vault-Token': token,
+            ...(vaultNamespace ? { 'X-Vault-Namespace': vaultNamespace } : {}),
           },
         },
       );

--- a/src/vault/vault.service.ts
+++ b/src/vault/vault.service.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AxiosResponse } from 'axios';
 import { HttpErrorByCode } from '@nestjs/common/utils/http-error-by-code.util';
@@ -14,6 +14,42 @@ export class VaultService {
     private readonly httpService: HttpService,
     private readonly configService: ConfigService,
   ) {}
+
+  /**
+   * 
+   * @param token - personal access token
+   * @returns 
+   */
+  async authGithub(token: string): Promise<string> {
+    const baseUrl: string = this.configService.get<string>('VAULT_BASE_URL');
+    const vaultNamespace: string = this.configService.get<string>('VAULT_NAMESPACE');
+
+    let result: AxiosResponse;
+    try {
+      result = await this.httpService.axiosRef.post(
+        `${baseUrl}/v1/auth/github/login`,
+        {
+          token: token,
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            ...(vaultNamespace ? { 'X-Vault-Namespace': vaultNamespace } : {}),
+          },
+        },
+      );
+
+      // log with stringify
+      Logger.log('Github login result: ', JSON.stringify(result.data));
+    }
+    catch (error) {
+      Logger.error('Failed to login with Personal Access Token', JSON.stringify(error));
+      throw new HttpErrorByCode[error.response.status]('VaultException');
+    }
+    const vault_token: string = result.data.auth.client_token;
+    return vault_token;
+  }
+
 
   async transitCreateKey(keyName: string, transitKeyPath: string, token: string): Promise<Buffer> {
     // https://developer.hashicorp.com/vault/api-docs/secret/transit#create-key
@@ -53,11 +89,19 @@ export class VaultService {
   async getKey(keyName: string, transitKeyPath: string, token: string): Promise<Buffer> {
     // https://developer.hashicorp.com/vault/api-docs/secret/transit#read-key
     const baseUrl: string = this.configService.get<string>('VAULT_BASE_URL');
+    const vaultNamespace: string = this.configService.get<string>('VAULT_NAMESPACE');
 
     let result: AxiosResponse;
     try {
-      result = await this.httpService.axiosRef.get(`${baseUrl}/v1/${transitKeyPath}/keys/${keyName}`, {
-        headers: { 'X-Vault-Token': token },
+      const url = `${baseUrl}/v1/${transitKeyPath}/keys/${keyName}`;
+      Logger.log('getKey url: ', url);
+
+      result = await this.httpService.axiosRef.get(url, {
+        headers: { 
+          'X-Vault-Token': token,
+          'Content-Type': 'application/json',
+          ...(vaultNamespace ? { 'X-Vault-Namespace': vaultNamespace } : {}),
+        },
       });
     } catch (error) {
       throw new HttpErrorByCode[error.response.status]('VaultException');

--- a/src/wallet/wallet.cli.controller.ts
+++ b/src/wallet/wallet.cli.controller.ts
@@ -36,6 +36,22 @@ export class WalletCLI {
 
 	/**
 	 *
+	 * @param personalAccessToken
+	 * @returns
+	 */
+	async loginWithToken(personalAccessToken: string): Promise<boolean> {
+		try {
+			const authResponse: string = await this.authService.authGithub(personalAccessToken);
+			this.latestVaultToken = authResponse;
+			return true;
+		} catch (error) {
+			Logger.error("Failed to login with Personal Access Token", error);
+			return false;
+		}
+	}
+
+	/**
+	 *
 	 * @returns
 	 */
 	async getAddress(keyPath: string = process.env.VAULT_TRANSIT_MANAGERS_PATH, keyName: string = process.env.VAULT_MANAGER_KEY): Promise<string> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,10 +1617,10 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.7.9:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
-  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
+axios@^1.8.2:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
+  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
Support using github access token to use with remotely deployed instance. 

The .env vars to be updated are:

- VAULT_TRANSIT_MANAGERS_PATH // path that you have access to
- VAULT_MANAGER_KEY // use your own key
- VAULT_BASE_URL // remote URL (if remotely deployed)
- VAULT_NAMESPACE // set this is vault is using namespaces

