### PR TITLE
feat: Add algo balance to GET requests on manager and users detail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pawn",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "author": "",
   "private": true,
@@ -82,5 +82,6 @@
       "/node_modules/",
       "/src/coverage/"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/chain/chain.service.ts
+++ b/src/chain/chain.service.ts
@@ -291,6 +291,15 @@ export class ChainService {
     return truncatedAccountResponse;
   }
 
+  // Get Algo Balance, fetch balance from AlgoD
+  async getAccountBalance(public_address: string): Promise<bigint> {
+    const response = await this.makeAlgoNodeRequest(`v2/accounts/${public_address}`, 'GET');
+
+    Logger.debug(`Account balance response: ${JSON.stringify(response)}`);
+
+    return BigInt(response['amount']);
+  }
+
   /**
    * Get the asset holding for a specific account and asset ID.
    * 

--- a/src/vault/vault.service.ts
+++ b/src/vault/vault.service.ts
@@ -239,8 +239,8 @@ export class VaultService {
     let usersObjs: UserInfoDto[] = [];
     for (let i = 0; i < users.length; i++) {
       let userObj = {
+        public_address: (await this.getKey(users[i], transitKeyPath, token)).toString('base64'), // TODO: rename public_address that is actually the public key in base64 format
         user_id: users[i],
-        public_address: (await this.getKey(users[i], transitKeyPath, token)).toString('base64'),
       };
       usersObjs.push(userObj);
     }

--- a/src/wallet/manager-detail.dto.ts
+++ b/src/wallet/manager-detail.dto.ts
@@ -8,4 +8,38 @@ export class ManagerDetailDto {
     description: 'The public address of the manager',
   })
   public_address?: string;
+
+  @ApiProperty({
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        asset_id: {
+          type: 'string',
+          example: '123456789',
+          description: 'The unique identifier of the asset',
+        },
+        asset_name: {
+          type: 'string',
+          example: 'Gold',
+          description: 'The name of the asset',
+        },
+        asset_amount: {
+          type: 'number',
+          example: 1000,
+          description: 'The amount of the asset held by the manager',
+        },
+      },
+    },
+    description: 'List of assets held by the manager',
+  })
+  assets: AssetHolding[];
+
+  @IsString()
+  @ApiProperty({
+    type: 'string',
+    example: '1000000',
+    description: 'The balance of Algorand held by the manager in microAlgos',
+  })  
+  algoBalance?: string;
 }

--- a/src/wallet/user-info-response.dto.ts
+++ b/src/wallet/user-info-response.dto.ts
@@ -15,4 +15,12 @@ export class UserInfoResponseDto {
     description: 'The public address of the User',
   })
   public_address: string;
+
+  @IsString()
+  @ApiProperty({
+    type: 'string',
+    example: '1000000',
+    description: 'The balance of Algorand held by the User in microAlgos',
+  })
+  algoBalance: string;
 }

--- a/src/wallet/wallet.controller.spec.ts
+++ b/src/wallet/wallet.controller.spec.ts
@@ -37,16 +37,17 @@ describe('Wallet Controller', () => {
       const userId = 'user123';
       const vaultToken = 'vault-token-abc';
       const expectedPublicAddress = 'PUBLIC_ADDRESS_XYZ';
+      const expectedAmount = '666';
 
       // Set up the WalletService mock for getUserPublicAddress.
-      mockWalletService.getUserInfo.mockResolvedValueOnce({ user_id: userId, public_address: expectedPublicAddress });
-
+      mockWalletService.getUserInfo.mockResolvedValueOnce({ user_id: userId, public_address: expectedPublicAddress, algoBalance: expectedAmount });
+[]
       const requestMock = { vault_token: vaultToken };
 
       const result = await walletController.userDetail(requestMock, userId);
 
       expect(mockWalletService.getUserInfo).toHaveBeenCalledWith(userId, vaultToken);
-      expect(result).toEqual({ user_id: userId, public_address: expectedPublicAddress });
+      expect(result).toEqual({ user_id: userId, public_address: expectedPublicAddress, algoBalance: expectedAmount });
     });
 
     it('\(OK) create user', async () => {
@@ -54,7 +55,7 @@ describe('Wallet Controller', () => {
       const vaultToken = 'vault-token-abc';
       const expectedPublicAddress = 'PUBLIC_ADDRESS_XYZ';
 
-      mockWalletService.userCreate.mockResolvedValueOnce({ user_id: userId, public_address: expectedPublicAddress });
+      mockWalletService.userCreate.mockResolvedValueOnce({ user_id: userId, public_address: expectedPublicAddress, algoBalance: '0' });
 
       const result: UserInfoResponseDto = await walletController.userCreate(
         { vault_token: vaultToken },
@@ -63,6 +64,8 @@ describe('Wallet Controller', () => {
 
       expect(result.user_id).toEqual(userId);
       expect(result.public_address).toEqual(expectedPublicAddress);
+      expect(result.algoBalance).toEqual('0'); // Initial balance is set to 0
+      expect(mockWalletService.userCreate).toHaveBeenCalledWith(userId, vaultToken);
     });
   });
 
@@ -71,6 +74,7 @@ describe('Wallet Controller', () => {
       const userId = 'user123';
       const vaultToken = 'vault-token-abc';
       const expectedPublicAddress = 'PUBLIC_ADDRESS_XYZ';
+      const algoBalanceExpected = '1000000'; // Example balance in microAlgos
       const expectedAssets: AssetHolding[] = [
         { amount: BigInt(100), 'asset-id': 123, 'is-frozen': false },
         { amount: BigInt(200), 'asset-id': 456, 'is-frozen': true },
@@ -81,7 +85,7 @@ describe('Wallet Controller', () => {
       };
       const requestMock = { vault_token: vaultToken };
       mockWalletService.getAssetHoldings.mockResolvedValueOnce(expectedAssets);
-      mockWalletService.getUserInfo.mockResolvedValueOnce({ user_id: userId, public_address: expectedPublicAddress });
+      mockWalletService.getUserInfo.mockResolvedValueOnce({ user_id: userId, public_address: expectedPublicAddress, algoBalance: algoBalanceExpected });
       const result = await walletController.assetsBalances(requestMock, userId);
       expect(mockWalletService.getAssetHoldings).toHaveBeenCalledWith(userId, vaultToken);
       expect(mockWalletService.getUserInfo).toHaveBeenCalledWith(userId, vaultToken);

--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Logger, Param, Post, Request } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Request } from '@nestjs/common';
 import { WalletService } from './wallet.service';
 import { CreateAssetDto } from './create-asset.dto';
 import { CreateAssetResponseDto } from './create-asset-response.dto';

--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Request } from '@nestjs/common';
+import { Body, Controller, Get, Logger, Param, Post, Request } from '@nestjs/common';
 import { WalletService } from './wallet.service';
 import { CreateAssetDto } from './create-asset.dto';
 import { CreateAssetResponseDto } from './create-asset-response.dto';

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -7,8 +7,6 @@ import { ConfigService } from '@nestjs/config';
 import { AlgorandEncoder } from '@algorandfoundation/algo-models';
 import { ManagerDetailDto } from './manager-detail.dto';
 import { plainToClass } from 'class-transformer';
-import { encode } from 'punycode';
-
 @Injectable()
 export class WalletService {
   constructor(

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -21,12 +21,13 @@ export class WalletService {
     const public_address = await this.vaultService.getUserPublicKey(user_id, vault_token);
 
     // get algo balance
-    const algoBalance: bigint = await this.chainService.getAccountBalance(new AlgorandEncoder().encodeAddress(public_address));
+    const encodedAddress = new AlgorandEncoder().encodeAddress(public_address);
+    const algoBalance: bigint = await this.chainService.getAccountBalance(encodedAddress);
     Logger.debug(`User ${user_id} Algo Balance: ${algoBalance}`);
 
     return { 
       user_id, 
-      public_address: new AlgorandEncoder().encodeAddress(public_address),
+      public_address: encodedAddress,
       algoBalance: algoBalance.toString(),
     };
   }

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -7,6 +7,7 @@ import { ConfigService } from '@nestjs/config';
 import { AlgorandEncoder } from '@algorandfoundation/algo-models';
 import { ManagerDetailDto } from './manager-detail.dto';
 import { plainToClass } from 'class-transformer';
+import { encode } from 'punycode';
 
 @Injectable()
 export class WalletService {
@@ -18,12 +19,36 @@ export class WalletService {
 
   async getUserInfo(user_id: string, vault_token: string): Promise<UserInfoResponseDto> {
     const public_address = await this.vaultService.getUserPublicKey(user_id, vault_token);
-    return { user_id, public_address: new AlgorandEncoder().encodeAddress(public_address) };
+
+    // get algo balance
+    const algoBalance: bigint = await this.chainService.getAccountBalance(new AlgorandEncoder().encodeAddress(public_address));
+    Logger.debug(`User ${user_id} Algo Balance: ${algoBalance}`);
+
+    return { 
+      user_id, 
+      public_address: new AlgorandEncoder().encodeAddress(public_address),
+      algoBalance: algoBalance.toString(),
+    };
   }
 
   async getManagerInfo(vault_token: string): Promise<ManagerDetailDto> {
     const public_address = await this.vaultService.getManagerPublicKey(vault_token);
-    return plainToClass(ManagerDetailDto, { public_address: new AlgorandEncoder().encodeAddress(public_address) });
+    // asset holdings 
+    const account: AssetHolding[] = await this.chainService.getAccountAssetHoldings(new AlgorandEncoder().encodeAddress(public_address));
+
+    // Log debug with stringify
+    Logger.debug(`Manager account details: ${JSON.stringify(account)}`);
+
+
+    // Get Algo Balance
+    const algoBalance: bigint = await this.chainService.getAccountBalance(new AlgorandEncoder().encodeAddress(public_address));
+    Logger.debug(`Manager Algo Balance: ${algoBalance}`);
+
+    return plainToClass(ManagerDetailDto, { 
+      public_address: new AlgorandEncoder().encodeAddress(public_address),
+      assets: account,
+      algoBalance: algoBalance.toString(),
+    });
   }
 
   // Create new user and key
@@ -32,17 +57,17 @@ export class WalletService {
 
     const public_key: Buffer = await this.vaultService.transitCreateKey(user_id, transitKeyPath, vault_token);
     const public_address: string = new AlgorandEncoder().encodeAddress(public_key);
-    return { user_id, public_address };
+    return { user_id, public_address, algoBalance: '0' }; // Initial balance is set to 0
   }
 
   // Get all users
   async getKeys(vault_token: string): Promise<UserInfoResponseDto[]> {
 
-
     const keys: UserInfoResponseDto[] = (await this.vaultService.getKeys(vault_token)) as UserInfoResponseDto[];
 
     // convert all public keys to algorand address
     keys.map((key) => {
+      
       key.public_address = new AlgorandEncoder().encodeAddress(Buffer.from(key.public_address, 'base64'));
     });
 

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -125,6 +125,7 @@ describe('App E2E', () => {
       expect(user_detail_response.data).toStrictEqual({
         user_id: user_uid,
         public_address: create_user_response.data.public_address,
+        algoBalance: '0', // Initial balance is set to 0
       });
     });
   });


### PR DESCRIPTION
# Algo Balances

Only ASA balances were being returned for managers and users. 

Adding algo amount to be returned on `wallet/manager` and `wallet/user/{user_id}`